### PR TITLE
smb: Reuse file handlers to improve multithreaded upload performance.

### DIFF
--- a/backend/smb/filepool.go
+++ b/backend/smb/filepool.go
@@ -1,0 +1,98 @@
+package smb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/cloudsoda/go-smb2"
+	"golang.org/x/sync/errgroup"
+)
+
+type file struct {
+	*smb2.File
+	c *conn
+}
+
+type filePool struct {
+	ctx   context.Context
+	fs    *Fs
+	share string
+	path  string
+
+	mu   sync.Mutex
+	pool []*file
+}
+
+func newFilePool(ctx context.Context, fs *Fs, share, path string) *filePool {
+	return &filePool{
+		ctx:   ctx,
+		fs:    fs,
+		share: share,
+		path:  path,
+	}
+}
+
+func (p *filePool) get() (*file, error) {
+	p.mu.Lock()
+	if len(p.pool) > 0 {
+		f := p.pool[len(p.pool)-1]
+		p.pool = p.pool[:len(p.pool)-1]
+		p.mu.Unlock()
+		return f, nil
+	}
+	p.mu.Unlock()
+
+	p.fs.addSession()
+
+	c, err := p.fs.getConnection(p.ctx, p.share)
+	if err != nil {
+		p.fs.removeSession()
+		return nil, err
+	}
+
+	fl, err := c.smbShare.OpenFile(p.path, os.O_WRONLY, 0o644)
+	if err != nil {
+		p.fs.putConnection(&c, err)
+		p.fs.removeSession()
+		return nil, fmt.Errorf("failed to open: %w", err)
+	}
+
+	return &file{File: fl, c: c}, nil
+}
+
+func (p *filePool) put(f *file, err error) {
+	if f == nil {
+		return
+	}
+
+	if err != nil {
+		_ = f.Close()
+		p.fs.putConnection(&f.c, err)
+		p.fs.removeSession()
+		return
+	}
+
+	p.mu.Lock()
+	p.pool = append(p.pool, f)
+	p.mu.Unlock()
+}
+
+func (p *filePool) drain() error {
+	p.mu.Lock()
+	files := p.pool
+	p.pool = nil
+	p.mu.Unlock()
+
+	g, _ := errgroup.WithContext(p.ctx)
+	for _, f := range files {
+		g.Go(func() error {
+			err := f.Close()
+			p.fs.putConnection(&f.c, err)
+			p.fs.removeSession()
+			return err
+		})
+	}
+	return g.Wait()
+}

--- a/backend/smb/smb.go
+++ b/backend/smb/smb.go
@@ -488,13 +488,31 @@ func (f *Fs) About(ctx context.Context) (_ *fs.Usage, err error) {
 	return usage, nil
 }
 
+type smbWriterAt struct {
+	pool *filePool
+}
+
+func (w *smbWriterAt) WriteAt(p []byte, off int64) (int, error) {
+	f, err := w.pool.get()
+	if err != nil {
+		return 0, err
+	}
+
+	n, writeErr := f.WriteAt(p, off)
+	w.pool.put(f, writeErr)
+	return n, writeErr
+}
+
+func (w *smbWriterAt) Close() error {
+	return w.pool.drain()
+}
+
 // OpenWriterAt opens with a handle for random access writes
 //
 // Pass in the remote desired and the size if known.
 //
 // It truncates any existing object
 func (f *Fs) OpenWriterAt(ctx context.Context, remote string, size int64) (fs.WriterAtCloser, error) {
-	var err error
 	o := &Object{
 		fs:     f,
 		remote: remote,
@@ -504,27 +522,39 @@ func (f *Fs) OpenWriterAt(ctx context.Context, remote string, size int64) (fs.Wr
 		return nil, fs.ErrorIsDir
 	}
 
-	err = o.fs.ensureDirectory(ctx, share, filename)
+	err := o.fs.ensureDirectory(ctx, share, filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make parent directories: %w", err)
 	}
 
-	filename = o.fs.toSambaPath(filename)
+	smbPath := o.fs.toSambaPath(filename)
 
-	o.fs.addSession() // Show session in use
-	defer o.fs.removeSession()
-
+	// One-time truncate
 	cn, err := o.fs.getConnection(ctx, share)
 	if err != nil {
 		return nil, err
 	}
-
-	fl, err := cn.smbShare.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	file, err := cn.smbShare.OpenFile(smbPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open: %w", err)
+		o.fs.putConnection(&cn, err)
+		return nil, err
 	}
+	if size > 0 {
+		if truncateErr := file.Truncate(size); truncateErr != nil {
+			_ = file.Close()
+			o.fs.putConnection(&cn, truncateErr)
+			return nil, fmt.Errorf("failed to truncate file: %w", truncateErr)
+		}
+	}
+	if closeErr := file.Close(); closeErr != nil {
+		o.fs.putConnection(&cn, closeErr)
+		return nil, fmt.Errorf("failed to close file after truncate: %w", closeErr)
+	}
+	o.fs.putConnection(&cn, nil)
 
-	return fl, nil
+	return &smbWriterAt{
+		pool: newFilePool(ctx, o.fs, share, smbPath),
+	}, nil
 }
 
 // Shutdown the backend, closing any background tasks and any

--- a/backend/smb/smb.go
+++ b/backend/smb/smb.go
@@ -3,6 +3,7 @@ package smb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -489,22 +490,64 @@ func (f *Fs) About(ctx context.Context) (_ *fs.Usage, err error) {
 }
 
 type smbWriterAt struct {
-	pool *filePool
+	pool    *filePool
+	closed  bool
+	closeMu sync.Mutex
+	wg      sync.WaitGroup
 }
 
 func (w *smbWriterAt) WriteAt(p []byte, off int64) (int, error) {
+	w.closeMu.Lock()
+	if w.closed {
+		w.closeMu.Unlock()
+		return 0, errors.New("writer already closed")
+	}
+	w.wg.Add(1)
+	w.closeMu.Unlock()
+	defer w.wg.Done()
+
 	f, err := w.pool.get()
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to get file from pool: %w", err)
 	}
 
 	n, writeErr := f.WriteAt(p, off)
 	w.pool.put(f, writeErr)
+
+	if writeErr != nil {
+		return n, fmt.Errorf("failed to write at offset %d: %w", off, writeErr)
+	}
+
 	return n, writeErr
 }
 
 func (w *smbWriterAt) Close() error {
-	return w.pool.drain()
+	w.closeMu.Lock()
+	defer w.closeMu.Unlock()
+
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+
+	// Wait for all pending writes to finish
+	w.wg.Wait()
+
+	var errs []error
+
+	// Drain the pool
+	if err := w.pool.drain(); err != nil {
+		errs = append(errs, fmt.Errorf("failed to drain file pool: %w", err))
+	}
+
+	// Remove session
+	w.pool.fs.removeSession()
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
 }
 
 // OpenWriterAt opens with a handle for random access writes
@@ -551,6 +594,9 @@ func (f *Fs) OpenWriterAt(ctx context.Context, remote string, size int64) (fs.Wr
 		return nil, fmt.Errorf("failed to close file after truncate: %w", closeErr)
 	}
 	o.fs.putConnection(&cn, nil)
+
+	// Add a new session
+	o.fs.addSession()
 
 	return &smbWriterAt{
 		pool: newFilePool(ctx, o.fs, share, smbPath),


### PR DESCRIPTION
This PR enhances the performance of SMB multithreaded uploads by introducing a **file handle pool** for each file path.

In the current design, `OpenWriterAt` provides the interface for random-access writes, and `openChunkWriterFromOpenWriterAt` wraps this interface to enable parallel chunk uploads using multiple goroutines. A global **connection pool** is already in place to manage SMB connections across files.

The proposed change introduces a **file handle pool,** which reuses file handles for repeated writes to the same file. By avoiding the overhead of repeatedly opening and closing file handles for each chunk write, this optimization **reduces latency** and **improves throughput**—especially over high-bandwidth links where file I/O becomes a bottleneck.

### Local testing

Measuring performance improvements in a development environment is challenging due to low bandwidth and various other limiting factors on the machine used for testing.
Nevertheless, I conducted several performance comparisons, and the summarized results are given below.


**SMB Server:**
- Architecture: `x86_64`
- CPU(s): `4` (2 sockets × 2 cores, 1 thread per core)
- Model: `QEMU Virtual CPU version 2.5+` (AuthenticAMD)
- Virtualization: `KVM`
- Memory: `4 GiB`
- L1 Cache: `256 KiB (data) + 256 KiB (instruction)`
- L2 Cache: `2 MiB`
- L3 Cache: `64 MiB`
- NUMA Node(s): `1` (CPUs 0–3)

**Note:** The server is running in a virtualized environment using KVM.

**SMB Client:**
- Model: `MacBook Pro (Mac14,7)`
- Chip: `Apple M2`
- CPU: `8-core (4 performance + 4 efficiency)`
- Memory: `8 GB`

**Test Files:**  
Three separate files, each **10 GB** in size. 

```bash
$ ls -lh build/smb-upload
total 62914560
-rw-r--r--@ 1 sudiptobaral  staff    10G Jun 23 12:23 dummy1-10Gb.dat
-rw-r--r--@ 1 sudiptobaral  staff    10G Jun 23 12:23 dummy2-10Gb.dat
-rw-r--r--@ 1 sudiptobaral  staff    10G Jun 23 12:23 dummy3-10Gb.dat

```

The following command was used to upload the files, where `--multi-thread-streams x` is used to control the number of threads. Note that, in this case, the default chunk size of **64MB** will be used.

```bash
rclone copy build/smb-upload/ smbtest:smbtest \
  --progress \
  --multi-thread-streams 16 \
  -vv
```

**Result:**


| Implementation | Threads | Test 1            | Test 2             | Test 3            |
|----------------|---------|-------------------|--------------------|-------------------|
| Master         | 4       | ███████ 693       | ███████ 724        | ████████ 805      |
| proposed       | 4       | ███████ 714       | ██████  547        | ███████  736      |
| Master         | 8       | ██████  534       | ███████ 628        | ███████  687      |
| proposed       | 8       | ██████  535       | ██████  520        | ███████  681      |
| Master         | 16      | ███████ 569       | ██████████ 965     | ███████  622      |
| proposed       | 16      | ██████  528       | ███████  622       | ██████  555       |

  _**Note:** Numbers are presented in seconds._
